### PR TITLE
Add photo permissions, sharing completion handler

### DIFF
--- a/SwiftRadio/Info.plist
+++ b/SwiftRadio/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>This app would like to save the image associated with the current track and station to your photo library.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/SwiftRadio/NowPlayingViewController.swift
+++ b/SwiftRadio/NowPlayingViewController.swift
@@ -320,6 +320,11 @@ class NowPlayingViewController: UIViewController {
     @IBAction func shareButtonPressed(_ sender: UIButton) {
         let songToShare = "I'm listening to \(currentTrack.title) on \(currentStation.name) via Swift Radio Pro"
         let activityViewController = UIActivityViewController(activityItems: [songToShare, currentTrack.artworkImage!], applicationActivities: nil)
+        activityViewController.completionWithItemsHandler = {(activityType: UIActivityType?, completed:Bool, returnedItems:[Any]?, error: Error?) in
+            if completed {
+                // do something on completion if you want
+            }
+        }
         present(activityViewController, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
 - NSPhotoLibraryAddUsageDescription lets user allow access to photo library (fixes silent crash when we try to save images)
 - Sharing completion handler fixes another error that occurs when we try to share something