### PR TITLE
track share button - now shares rendered track image instead of text

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,18 @@ A: While I have a full-time job and other project obligations, I'd highly recomm
 Q: The song names aren't appearing for my station?  
 A: Check with your stream provider to make sure they are sending Metadata properly. If a station sends data in a unique way, you can modify the way the app parses the metadata, in the `RadioPlayer` class implement `FRadioPlayerDelegate` method: `radioPlayer(_ player: FRadioPlayer, metadataDidChange rawValue: String?)`.
 
-## Single Station Code
-We can create a single station version of this code for you for a small fee. Send a friendly email to [Matthew](mailto:matthew@audiokitpro.com) or [Fethi](mailto:contact@fethica.com).
+## Get Single Station Code
+If you'd like to support this project, co-orgainizer Fethi has created a well-architected single station version of this code. It's a super great bargain: The developers behind this project typically charge up to $200/hr for freelance work, but this fully working code is only $50. No extra fees. 
+
+You can PayPal: [fethica@me.com](mailto:fethica@me.com) or use this link: [Paypal Me](https://www.paypal.me/fethicaEH)
+We will send you the code after 24 hours with setup instructions. All funds go to support the project.
+
+**Need something more advanced?** We have recent experience building iOS apps for high-profile brands. Send a friendly email to [Matthew](mailto:matthew@audiokitpro.com) or [Fethi](mailto:contact@fethica.com).
 
 
 ## RadioKit SDK Example 
 
-![alt text](http://matthewfecher.com/wp-content/uploads/2015/11/radiokit.jpg "RadioKit Example")
+[alt text](http://matthewfecher.com/wp-content/uploads/2015/11/radiokit.jpg "RadioKit Example")
 
 - You can use this Swift code as a front-end for a more robust streaming backend.
 - Brian Stormont, creator of RadioKit, has created a branch with the professional [RadioKit](http://stormyprods.com/products/radiokit.php) SDK already integrated. **Plus, his branch adds rewind & fast forward stream playback.** This is an excellent learning tool for those who are interested in seeing how a streaming library integrates with Swift Radio Pro. View the [branch here](https://github.com/MostTornBrain/Swift-Radio-Pro/tree/RadioKit).

--- a/SwiftRadio.xcodeproj/project.pbxproj
+++ b/SwiftRadio.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		5F22BA551F72AD5A00CB5911 /* AutoTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F22BA3A1F72AD5800CB5911 /* AutoTextView.swift */; };
 		5F22BA561F72AD5A00CB5911 /* DesignableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F22BA3B1F72AD5900CB5911 /* DesignableView.swift */; };
 		5FDEE0221F72FF980064333C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5FDEE0211F72FF980064333C /* LaunchScreen.storyboard */; };
+		6258DCD822D93A3500166C65 /* LogoShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6258DCD722D93A3500166C65 /* LogoShareView.swift */; };
+		6258DCDA22D93A5400166C65 /* LogoShareView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6258DCD922D93A5400166C65 /* LogoShareView.xib */; };
 		81AD229B21646DEA002ADFDD /* FRadioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81AD229821646DEA002ADFDD /* FRadioPlayer.swift */; };
 		81AD229C21646DEA002ADFDD /* FRadioAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81AD229921646DEA002ADFDD /* FRadioAPI.swift */; };
 		81AD229D21646DEA002ADFDD /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81AD229A21646DEA002ADFDD /* Reachability.swift */; };
@@ -105,6 +107,8 @@
 		5F22BA3A1F72AD5800CB5911 /* AutoTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTextView.swift; sourceTree = "<group>"; };
 		5F22BA3B1F72AD5900CB5911 /* DesignableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignableView.swift; sourceTree = "<group>"; };
 		5FDEE0211F72FF980064333C /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		6258DCD722D93A3500166C65 /* LogoShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoShareView.swift; sourceTree = "<group>"; };
+		6258DCD922D93A5400166C65 /* LogoShareView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LogoShareView.xib; sourceTree = "<group>"; };
 		81AD229821646DEA002ADFDD /* FRadioPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FRadioPlayer.swift; sourceTree = "<group>"; };
 		81AD229921646DEA002ADFDD /* FRadioAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FRadioAPI.swift; sourceTree = "<group>"; };
 		81AD229A21646DEA002ADFDD /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
@@ -274,6 +278,8 @@
 				94D1D0A41AD6D6230022CA11 /* InfoDetailViewController.swift */,
 				94452E4E1AD6F24700BFE7A5 /* PopUpMenuViewController.swift */,
 				9409E13F1ABF78B000312E2B /* NowPlayingViewController.swift */,
+				6258DCD722D93A3500166C65 /* LogoShareView.swift */,
+				6258DCD922D93A5400166C65 /* LogoShareView.xib */,
 				942A3F361AE43DF80011396E /* StationsViewController.swift */,
 			);
 			name = ViewControllers;
@@ -373,7 +379,7 @@
 					};
 					9409E1151ABF6FEA00312E2B = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = G24WJ3XCZ3;
+						DevelopmentTeam = 79VHH58USY;
 						LastSwiftMigration = 1020;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -417,6 +423,7 @@
 			files = (
 				945DB3C21AD58E3A00495EBB /* stations.json in Resources */,
 				945DB3C51AD5A6E200495EBB /* NothingFoundCell.xib in Resources */,
+				6258DCDA22D93A5400166C65 /* LogoShareView.xib in Resources */,
 				CF72ACE721F7155200461EED /* Main.storyboard in Resources */,
 				5FDEE0221F72FF980064333C /* LaunchScreen.storyboard in Resources */,
 				9409E1261ABF6FEA00312E2B /* Images.xcassets in Resources */,
@@ -454,6 +461,7 @@
 				94D1D0A51AD6D6230022CA11 /* InfoDetailViewController.swift in Sources */,
 				5F22BA4B1F72AD5A00CB5911 /* KeyboardLayoutConstraint.swift in Sources */,
 				5F22BA421F72AD5A00CB5911 /* SoundPlayer.swift in Sources */,
+				6258DCD822D93A3500166C65 /* LogoShareView.swift in Sources */,
 				5F22BA4A1F72AD5A00CB5911 /* DesignableTextView.swift in Sources */,
 				949BBB401ACC9DEE005B7C26 /* DataManager.swift in Sources */,
 				5F22BA4E1F72AD5A00CB5911 /* Misc.swift in Sources */,
@@ -639,6 +647,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 79VHH58USY;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/SwiftRadio",
@@ -662,6 +671,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 79VHH58USY;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/SwiftRadio",

--- a/SwiftRadio/LogoShareView.swift
+++ b/SwiftRadio/LogoShareView.swift
@@ -1,0 +1,36 @@
+//
+//  LogoShareView.swift
+//  SwiftRadio
+//
+//  Created by Cameron Mcleod on 2019-07-12.
+//  Copyright © 2019 matthewfecher.com. All rights reserved.
+//
+
+import UIKit
+
+class LogoShareView: UIView {
+    
+    @IBOutlet weak var albumArt: UIImageView!
+    @IBOutlet weak var radioShoutoutLabel: UILabel!
+    @IBOutlet weak var trackTitleLabel: UILabel!
+    @IBOutlet weak var trackArtistLabel: UILabel!
+    @IBOutlet weak var logoImageView: UIImageView!
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+    
+    func shareSetup(albumArt : UIImage, radioShoutout: String, trackTitle: String, trackArtist: String) {
+        
+        self.albumArt.image = albumArt
+        self.radioShoutoutLabel.text = radioShoutout
+        self.trackTitleLabel.text = trackTitle
+        self.trackArtistLabel.text = trackArtist
+        self.logoImageView.image = UIImage(named: "logo")
+    }
+
+}

--- a/SwiftRadio/LogoShareView.xib
+++ b/SwiftRadio/LogoShareView.xib
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="LogoShareView" customModule="SwiftRadio" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="sgO-Os-qNc" userLabel="Main Stack">
+                    <rect key="frame" x="8" y="8" width="584" height="584"/>
+                    <subviews>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zmo-M8-m9o" userLabel="Album Art">
+                            <rect key="frame" x="0.0" y="0.0" width="584" height="435"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="435" id="odw-Xz-Dzz"/>
+                            </constraints>
+                        </imageView>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="tPe-Vc-KR3" userLabel="Track Info">
+                            <rect key="frame" x="0.0" y="455" width="584" height="88"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ptC-tD-gdN" userLabel="Title">
+                                    <rect key="frame" x="0.0" y="0.0" width="181.5" height="88"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
+                                    <color key="highlightedColor" cocoaTouchSystemColor="lightTextColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UhH-FP-Yas" userLabel="Artist">
+                                    <rect key="frame" x="201.5" y="0.0" width="181" height="88"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
+                                    <color key="highlightedColor" cocoaTouchSystemColor="lightTextColor"/>
+                                </label>
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Wb0-C0-hGr" userLabel="Logo">
+                                    <rect key="frame" x="402.5" y="0.0" width="181.5" height="88"/>
+                                </imageView>
+                            </subviews>
+                        </stackView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LsP-Sq-acL" userLabel="Radio Shoutout">
+                            <rect key="frame" x="0.0" y="563" width="584" height="21"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="21" id="gRG-0o-oJ8"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="sgO-Os-qNc" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="8" id="Mtg-2A-d5g"/>
+                <constraint firstItem="sgO-Os-qNc" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="PAp-lT-AWa"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="sgO-Os-qNc" secondAttribute="trailing" constant="8" id="Ydx-tF-aHS"/>
+                <constraint firstAttribute="bottom" secondItem="sgO-Os-qNc" secondAttribute="bottom" constant="8" id="f80-X9-fsP"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <connections>
+                <outlet property="albumArt" destination="zmo-M8-m9o" id="E3I-ds-amX"/>
+                <outlet property="logoImageView" destination="Wb0-C0-hGr" id="P1S-1A-jy7"/>
+                <outlet property="radioShoutoutLabel" destination="LsP-Sq-acL" id="o6j-gY-1Wg"/>
+                <outlet property="trackArtistLabel" destination="UhH-FP-Yas" id="NR4-tS-aF6"/>
+                <outlet property="trackTitleLabel" destination="ptC-tD-gdN" id="EHQ-oR-a74"/>
+            </connections>
+        </view>
+    </objects>
+</document>

--- a/SwiftRadio/LogoShareView.xib
+++ b/SwiftRadio/LogoShareView.xib
@@ -28,13 +28,13 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="tPe-Vc-KR3" userLabel="Track Info">
                             <rect key="frame" x="0.0" y="455" width="584" height="88"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ptC-tD-gdN" userLabel="Title">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ptC-tD-gdN" userLabel="Title">
                                     <rect key="frame" x="0.0" y="0.0" width="181.5" height="88"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
                                     <color key="highlightedColor" cocoaTouchSystemColor="lightTextColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UhH-FP-Yas" userLabel="Artist">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UhH-FP-Yas" userLabel="Artist">
                                     <rect key="frame" x="201.5" y="0.0" width="181" height="88"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>

--- a/SwiftRadio/NowPlayingViewController.swift
+++ b/SwiftRadio/NowPlayingViewController.swift
@@ -347,17 +347,31 @@ class NowPlayingViewController: UIViewController {
     }
     
     @IBAction func shareButtonPressed(_ sender: UIButton) {
-        let songToShare = "I'm listening to \(currentTrack.title) on \(currentStation.name) via Swift Radio Pro"
-        let activityViewController = UIActivityViewController(activityItems: [songToShare, currentTrack.artworkImage!], applicationActivities: nil)
-        activityViewController.popoverPresentationController?.sourceRect = CGRect(x: view.center.x, y: view.center.y, width: 0, height: 0)
-        activityViewController.popoverPresentationController?.sourceView = view
-        activityViewController.popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection(rawValue: 0)
         
-        activityViewController.completionWithItemsHandler = {(activityType: UIActivity.ActivityType?, completed:Bool, returnedItems:[Any]?, error: Error?) in
-            if completed {
-                // do something on completion if you want
+        let songToShare = "I'm listening to \(currentStation.name) via Swift Radio Pro"
+        let shareImage : UIImage?
+        if let objects = Bundle.main.loadNibNamed("LogoShareView", owner: nil, options: [:]), let getView = objects.first {
+            
+            if let logoShare = getView as? LogoShareView {
+                logoShare.shareSetup(albumArt: currentTrack.artworkImage!, radioShoutout: songToShare, trackTitle: currentTrack.title, trackArtist: currentTrack.artist)
+                UIGraphicsBeginImageContextWithOptions(CGSize(width: logoShare.frame.width, height: logoShare.frame.height), true, 0)
+                logoShare.drawHierarchy(in: logoShare.frame, afterScreenUpdates: true)
+                shareImage = UIGraphicsGetImageFromCurrentImageContext()
+                UIGraphicsEndImageContext();
+
+                
+                let activityViewController = UIActivityViewController(activityItems: [shareImage!], applicationActivities: nil)
+                activityViewController.popoverPresentationController?.sourceRect = CGRect(x: view.center.x, y: view.center.y, width: 0, height: 0)
+                activityViewController.popoverPresentationController?.sourceView = view
+                activityViewController.popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection(rawValue: 0)
+                
+                activityViewController.completionWithItemsHandler = {(activityType: UIActivity.ActivityType?, completed:Bool, returnedItems:[Any]?, error: Error?) in
+                    if completed {
+                        // do something on completion if you want
+                    }
+                }
+                present(activityViewController, animated: true, completion: nil)
             }
         }
-        present(activityViewController, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
changed share track so 'I'm listening to \(currentStation.name) via Swift Radio Pro' is now a subtitle in a watermarked image with the album art, artist and song name to share." 

![Image-1](https://user-images.githubusercontent.com/12669361/62650895-a75ac280-b90c-11e9-9bc9-8594fc932e0b.jpg)

Radios without song metadata are displayed with the radio logo and information. 

![IMG_1903](https://user-images.githubusercontent.com/12669361/62650951-cb1e0880-b90c-11e9-95a8-bf72e5279fa0.JPG)

