### PR TITLE
Fix when reloading station after selecting it again from the station …

### DIFF
--- a/SwiftRadio/StationsViewController.swift
+++ b/SwiftRadio/StationsViewController.swift
@@ -36,6 +36,8 @@ class StationsViewController: UIViewController {
     
     var searchedStations = [RadioStation]()
     
+    var previousStation: RadioStation?
+    
     // MARK: - UI
     
     var searchController: UISearchController = {
@@ -185,7 +187,8 @@ class StationsViewController: UIViewController {
         if let indexPath = (sender as? IndexPath) {
             // User clicked on row, load/reset station
             radioPlayer.station = searchController.isActive ? searchedStations[indexPath.row] : stations[indexPath.row]
-            newStation = true
+            newStation = radioPlayer.station != previousStation
+            previousStation = radioPlayer.station
         } else {
             // User clicked on Now Playing button
             newStation = false


### PR DESCRIPTION
…list caused the stream to reload.

Steps to reproduce:
- select a station from the station list
- arrive to the Now Playing screen
- go back to the previous screen
- select the previously selected station

Actual result: the station reloads causing a short pause in the stream

Expected result: there's no pause to the stream, transitioning back to the Now Playing screen works  like tapping the Now Playing button.