### PR TITLE
Use AnyObject instead of class

### DIFF
--- a/SwiftRadio/Libraries/FRadioPlayer/FRadioPlayer.swift
+++ b/SwiftRadio/Libraries/FRadioPlayer/FRadioPlayer.swift
@@ -76,7 +76,7 @@ import AVFoundation
  The `FRadioPlayerDelegate` protocol defines methods you can implement to respond to playback events associated with an `FRadioPlayer` object.
  */
 
-@objc public protocol FRadioPlayerDelegate: class {
+@objc public protocol FRadioPlayerDelegate: AnyObject {
     /**
      Called when player changes state
      

--- a/SwiftRadio/NowPlayingViewController.swift
+++ b/SwiftRadio/NowPlayingViewController.swift
@@ -15,7 +15,7 @@ import AVKit
 // NowPlayingViewControllerDelegate
 //*****************************************************************
 
-protocol NowPlayingViewControllerDelegate: class {
+protocol NowPlayingViewControllerDelegate: AnyObject {
     func didPressPlayingButton()
     func didPressStopButton()
     func didPressNextButton()

--- a/SwiftRadio/RadioPlayer.swift
+++ b/SwiftRadio/RadioPlayer.swift
@@ -12,7 +12,7 @@ import UIKit
 // RadioPlayerDelegate: Sends FRadioPlayer and Station/Track events
 //*****************************************************************
 
-protocol RadioPlayerDelegate: class {
+protocol RadioPlayerDelegate: AnyObject {
     func playerStateDidChange(_ playerState: FRadioPlayerState)
     func playbackStateDidChange(_ playbackState: FRadioPlaybackState)
     func trackDidUpdate(_ track: Track?)


### PR DESCRIPTION
Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead